### PR TITLE
Android Gboard typing and cursor fixes

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -153,6 +153,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
   };
 
   _blockSelectEvents: boolean;
+  _blockInputEvents: boolean;
   _clipboard: ?BlockMap;
   _handler: ?Object;
   _dragCount: number;

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -138,9 +138,10 @@ const DraftEditorCompositionHandler = {
       // composition and reinterpret the key press in edit mode.
       DraftEditorCompositionHandler.resolveComposition(editor);
       editor._onKeyDown(e);
-      setTimeout(
-        () => editor.restoreEditorDOM({x: window.scrollX, y: window.scrollY}),
-        0,
+      editor.update(
+        EditorState.set(editor._latestEditorState, {
+          nativelyRenderedContent: editor._latestEditorState.getCurrentContent(),
+        }),
       );
       return;
     }

--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -79,7 +79,10 @@ const DraftEditorCompositionHandler = {
    * twice could break the DOM, we only use the first event. Example: Arabic
    * Google Input Tools on Windows 8.1 fires `compositionend` three times.
    */
-  onCompositionEnd: function(editor: DraftEditor, e: SyntheticKeyboardEvent<>): void {
+  onCompositionEnd: function(
+    editor: DraftEditor,
+    e: SyntheticInputEvent<>,
+  ): void {
     resolved = false;
     stillComposing = false;
 
@@ -107,7 +110,9 @@ const DraftEditorCompositionHandler = {
    * Gboard keyboard don't send valid keyDown event
    * for backspace button only when merging blocks
    */
-  onInput: function (editor: DraftEditor, e: SyntheticKeyboardEvent<>): void {
+  onInput: function(editor: DraftEditor, e: SyntheticInputEvent<>): void {
+    /* $FlowFixMe inputType is only defined on a draft of a standard.
+     * https://w3c.github.io/input-events/#dom-inputevent-inputtype */
     if (e.nativeEvent.inputType === 'deleteContentBackward') {
       editOnInput(editor, e);
     }
@@ -133,7 +138,10 @@ const DraftEditorCompositionHandler = {
       // composition and reinterpret the key press in edit mode.
       DraftEditorCompositionHandler.resolveComposition(editor);
       editor._onKeyDown(e);
-      setTimeout(() => editor.restoreEditorDOM({x: window.scrollX, y: window.scrollY}), 0);
+      setTimeout(
+        () => editor.restoreEditorDOM({x: window.scrollX, y: window.scrollY}),
+        0,
+      );
       return;
     }
     if (e.which === Keys.RIGHT || e.which === Keys.LEFT) {

--- a/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
+++ b/src/component/handlers/composition/__tests__/DraftEditorCompostionHandler-test.js
@@ -25,6 +25,7 @@ const SelectionState = require('SelectionState');
 const convertFromHTMLToContentBlocks = require('convertFromHTMLToContentBlocks');
 const editOnCompositionStart = require('editOnCompositionStart');
 const {Map} = require('immutable');
+const compositionEvent = {data: ''};
 
 jest.mock('DOMObserver', () => {
   function DOMObserver() {}
@@ -112,7 +113,7 @@ test('isInCompositionMode is properly updated on composition events', () => {
   expect(editor.setMode).toHaveBeenLastCalledWith('composite');
   expect(editor._latestEditorState.isInCompositionMode()).toBe(true);
   // $FlowExpectedError
-  compositionHandler.onCompositionEnd(editor);
+  compositionHandler.onCompositionEnd(editor, compositionEvent);
   jest.runAllTimers();
   expect(editor._latestEditorState.isInCompositionMode()).toBe(false);
   expect(editor.exitCurrentMode).toHaveBeenCalled();
@@ -128,7 +129,7 @@ test('Can handle a single mutation', () => {
     // $FlowExpectedError
     compositionHandler.onCompositionStart(editor);
     // $FlowExpectedError
-    compositionHandler.onCompositionEnd(editor);
+    compositionHandler.onCompositionEnd(editor, compositionEvent);
     jest.runAllTimers();
 
     expect(editorTextContent()).toBe('\u79c1');
@@ -151,7 +152,7 @@ test('Can handle mutations in multiple blocks', () => {
     // $FlowExpectedError
     compositionHandler.onCompositionStart(editor);
     // $FlowExpectedError
-    compositionHandler.onCompositionEnd(editor);
+    compositionHandler.onCompositionEnd(editor, compositionEvent);
     jest.runAllTimers();
 
     expect(editorTextContent()).toBe('reactjs\ndraftjs');
@@ -179,7 +180,7 @@ test('Can handle mutations in the same block in multiple leaf nodes', () => {
     // $FlowExpectedError
     compositionHandler.onCompositionStart(editor);
     // $FlowExpectedError
-    compositionHandler.onCompositionEnd(editor);
+    compositionHandler.onCompositionEnd(editor, compositionEvent);
     jest.runAllTimers();
 
     expect(editorTextContent()).toBe('reacta draftbb graphqlccc');

--- a/src/component/handlers/edit/DraftEditorEditHandler.js
+++ b/src/component/handlers/edit/DraftEditorEditHandler.js
@@ -28,9 +28,9 @@ const onKeyDown = require('editOnKeyDown');
 const onPaste = require('editOnPaste');
 const onSelect = require('editOnSelect');
 
-const isChrome = UserAgent.isBrowser('Chrome');
+const isAndroid = UserAgent.isPlatform('Android');
 
-const selectionHandler: (e: DraftEditor) => void = isChrome
+const selectionHandler: (e: DraftEditor) => void = isAndroid
   ? onSelect
   : e => {};
 
@@ -47,7 +47,7 @@ const DraftEditorEditHandler = {
   onKeyDown,
   onPaste,
   onSelect,
-  // In certain cases, contenteditable on chrome does not fire the onSelect
+  // In certain cases, contenteditable on android does not fire the onSelect
   // event, causing problems with cursor positioning. Therefore, the selection
   // state update handler is added to more events to ensure that the selection
   // state is always synced with the actual cursor positions.

--- a/src/component/handlers/edit/DraftEditorEditHandler.js
+++ b/src/component/handlers/edit/DraftEditorEditHandler.js
@@ -28,11 +28,11 @@ const onKeyDown = require('editOnKeyDown');
 const onPaste = require('editOnPaste');
 const onSelect = require('editOnSelect');
 
+const isChrome = UserAgent.isBrowser('Chrome');
 const isAndroid = UserAgent.isPlatform('Android');
 
-const selectionHandler: (e: DraftEditor) => void = isAndroid
-  ? onSelect
-  : e => {};
+const selectionHandler: (e: DraftEditor) => void =
+  isChrome || isAndroid ? onSelect : e => {};
 
 const DraftEditorEditHandler = {
   onBeforeInput,
@@ -47,7 +47,7 @@ const DraftEditorEditHandler = {
   onKeyDown,
   onPaste,
   onSelect,
-  // In certain cases, contenteditable on android does not fire the onSelect
+  // In certain cases, contenteditable on chrome does not fire the onSelect
   // event, causing problems with cursor positioning. Therefore, the selection
   // state update handler is added to more events to ensure that the selection
   // state is always synced with the actual cursor positions.

--- a/src/component/handlers/edit/editOnInput.js
+++ b/src/component/handlers/edit/editOnInput.js
@@ -92,7 +92,7 @@ function editOnInput(editor: DraftEditor, e: SyntheticInputEvent<>): void {
     anchorNode.nodeType !== Node.TEXT_NODE &&
     anchorNode.nodeType !== Node.ELEMENT_NODE;
 
-  if (isNotTextOrElementNode) {
+  if (isNotTextOrElementNode || editor._blockInputEvents) {
     // TODO: (t16149272) figure out context for this change
     return;
   }

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -113,7 +113,7 @@ function editOnKeyDown(
       if (isAndroid) {
         // Gboard keybord is sending backspace onInput event after spliting a word
         editor._blockInputEvents = true;
-        setTimeout(() => editor._blockInputEvents = false, 0);
+        setTimeout(() => (editor._blockInputEvents = false), 0);
       }
       // The top-level component may manually handle newline insertion. If
       // no special handling is performed, fall through to command handling.

--- a/src/component/handlers/edit/editOnKeyDown.js
+++ b/src/component/handlers/edit/editOnKeyDown.js
@@ -35,6 +35,7 @@ const keyCommandUndo = require('keyCommandUndo');
 
 const {isOptionKeyCommand} = KeyBindingUtil;
 const isChrome = UserAgent.isBrowser('Chrome');
+const isAndroid = UserAgent.isPlatform('Android');
 
 /**
  * Map a `DraftEditorCommand` command value to a corresponding function.
@@ -109,6 +110,11 @@ function editOnKeyDown(
   switch (keyCode) {
     case Keys.RETURN:
       e.preventDefault();
+      if (isAndroid) {
+        // Gboard keybord is sending backspace onInput event after spliting a word
+        editor._blockInputEvents = true;
+        setTimeout(() => editor._blockInputEvents = false, 0);
+      }
       // The top-level component may manually handle newline insertion. If
       // no special handling is performed, fall through to command handling.
       if (


### PR DESCRIPTION
**Android v10 Gboard keyboard are missing some keyDown events and send invalid onInput events**

Composition events are used only on Android, iOS is not sending them.

Task: RICH-311
